### PR TITLE
対応するドメインにtunnelto.devを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rangrok
 [![CircleCI](https://circleci.com/gh/haruelico/rangrok/tree/master.svg?style=svg)](https://circleci.com/gh/haruelico/rangrok/tree/master)
 
-Add `.ngrok.io` , `.localtunnel.me`, and `.serveo.net` to `Rails.application.config.hosts` in development environment.
+Add `.ngrok.io` , `.localtunnel.me`, `.serveo.net`,  and `.tunnelto.dev` to `Rails.application.config.hosts` in development environment.
 
 (Naming is __Ra__ ils and ngrok.)
 

--- a/lib/rangrok/railtie.rb
+++ b/lib/rangrok/railtie.rb
@@ -11,5 +11,9 @@ module Rangrok
     initializer 'rangrok_add_serveo_to_allowed_hosts' do
       Rails.application.config.hosts << ".serveo.net" if Rails.env.development?
     end
+
+    initializer 'rangrok_add_tunnelto_to_allowed_hosts' do
+      Rails.application.config.hosts << ".tunnelto.dev" if Rails.env.development?
+    end
   end
 end

--- a/lib/rangrok/version.rb
+++ b/lib/rangrok/version.rb
@@ -1,3 +1,3 @@
 module Rangrok
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/rangrok.gemspec
+++ b/rangrok.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", "~> 6.0.0"
+  spec.add_dependency "rails", ">= 6.0.0"
 
   spec.add_development_dependency "sqlite3"
 end

--- a/test/rangrok_test.rb
+++ b/test/rangrok_test.rb
@@ -16,4 +16,8 @@ class Rangrok::Test < ActiveSupport::TestCase
   test 'allow request from "*.serveo.net"' do
     assert_includes Rails.application.config.hosts, ".serveo.net"
   end
+
+  test 'allow request from "*.tunnelto.dev"' do
+    assert_includes Rails.application.config.hosts, ".tunnelto.dev"
+  end
 end


### PR DESCRIPTION
最近tunnelto.devが流行りらしいので自分で使いたいから追加してみました
よかったら取り入れて下さい

verを勝手に0.4.0にしてますがそこらへんはよしなにお願いしますm(_ _)m
あと、Railsの指定が`~> 6.0.0`となっていたのですが`6.1.x`で使いたかったので`>= 6.0.0`に変えてます。ダメだったらこれもよしなにお願いします！！！

参考: https://qiita.com/homhom_star/items/0a401a1075060fe2de4b